### PR TITLE
Ignore errors on closing sockets

### DIFF
--- a/src/socket.ts
+++ b/src/socket.ts
@@ -199,10 +199,11 @@ export class ConstellationSocket extends EventEmitter {
 
         this.socket.addEventListener('error', err => {
             if (this.state === State.Closing) {
-                this.emit('close');
-            } else {
-                this.emit('error', err);
+                // Ignore errors on a closing socket.
+                return;
             }
+
+            this.emit('error', err);
         });
 
         return this;


### PR DESCRIPTION
Previously, when you manually closed a socket and an error fired as you
did so, it would fire the close event twice on the socket, once for the
error, and once for the actual close. This was causing the reconnection
logic to fire twice, the first time realising it was a clean close, and
the second thinking it was an error, therefor reconnecting.
