### PR TITLE
Remove core-js in favour of ts libs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ws": "^1.1.1"
   },
   "dependencies": {
-    "@types/core-js": "^0.9.34",
     "@types/node": "^6.0.45",
     "@types/pako": "^0.2.31",
     "pako": "^1.0.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,15 @@
         "module": "commonjs",
         "target": "es5",
         "sourceMap": true,
-        "outDir": "./lib"
+        "outDir": "./lib",
+        "lib": [
+            "dom",
+            "es5",
+            "es2015.collection",
+            "es2015.promise",
+            "es2015.iterable",
+            "es2015.core"
+        ]
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
Having @types/core-js in dependencies means any consumer with an es2015 target cannot use Carina as it conflicts with the core-js typings. Moving them back to dev would fix it, but this is nicer anyway.
