### PR TITLE
Simplify and solidify subscriptions, allow multiple listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chai": "^3.5.0",
     "chai-subset": "^1.3.0",
     "mocha": "^3.0.2",
-    "sinon": "^1.17.5",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "ts-node": "^2.1.0",
     "typescript": "^2.1.6",

--- a/src/packets.ts
+++ b/src/packets.ts
@@ -7,17 +7,15 @@ export enum PacketState {
     // waiting for a reply.
     Sending,
     // The packet was replied to, and has now been complete.
-    Replied,
-    // The caller has indicated they no longer wish to be notified about this event.
-    Cancelled
+    Replied
 }
-
-const maxInt32 = 0xFFFFFFFF;
 
 /**
  * A Packet is a data type that can be sent over the wire to Constellation.
  */
 export class Packet extends EventEmitter {
+    private static packetIncr = 0;
+
     private state: PacketState = PacketState.Pending;
     private timeout: number;
     private data: {
@@ -30,7 +28,7 @@ export class Packet extends EventEmitter {
     constructor(method: string, params: { [key: string]: any }) {
         super();
         this.data = {
-            id: Math.floor(Math.random() * maxInt32),
+            id: Packet.packetIncr++,
             type: 'method',
             method,
             params,
@@ -43,14 +41,6 @@ export class Packet extends EventEmitter {
      */
     id(): number {
         return this.data.id;
-    }
-
-    /**
-     * Aborts sending the message, if it has not been sent yet.
-     */
-    cancel() {
-        this.emit('cancel');
-        this.setState(PacketState.Cancelled);
     }
 
     /**
@@ -83,6 +73,10 @@ export class Packet extends EventEmitter {
         return this.state;
     }
 
+    /**
+     * Updates the state of the packet.
+     * @param {PacketState} state
+     */
     setState(state: PacketState) {
         if (state === this.state) {
             return;

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -1,0 +1,82 @@
+import { ConstellationSocket, State } from './socket';
+
+/**
+ * Subscription is attached to a socket and tracks listening functions.
+ */
+export class Subscription<T> {
+
+    private listeners: ((data: T) => void)[] = [];
+    private socketStateListener: (state: State) => void;
+    private socketDataListener: (ev: { channel: string, payload: T }) => void;
+
+    constructor(private socket: ConstellationSocket, private slug: string) {}
+
+    /**
+     * add inserts the listener into the subscription
+     */
+    public add(listener: (data: T) => void): void {
+        if (this.listeners.length === 0) {
+            this.addSocketListener();
+        }
+
+        this.listeners.push(listener);
+    }
+
+    /**
+     * remove removes the listening function.
+     */
+    public remove(listener: (data: T) => void): void {
+        this.listeners = this.listeners.filter(l => l !== listener);
+        if (this.listeners.length === 0) {
+            this.removeSocketListener();
+        }
+    }
+
+    /**
+     * removeAll destroys all listening functions and unsubscribes from the socket.
+     */
+    public removeAll(): void {
+        this.listeners = [];
+        this.removeSocketListener();
+    }
+
+    /**
+     * Returns the number of listening functions attached to the subscription.
+     */
+    public listenerCount(): number {
+        return this.listeners.length;
+    }
+
+    private addSocketListener() {
+        this.socketStateListener = state => {
+            if (state === State.Connected) {
+                this.socket.execute('livesubscribe', { events: [this.slug] });
+            }
+        };
+
+        this.socketDataListener = ev => {
+            if (ev.channel === this.slug) {
+                this.listeners.forEach(l => l(ev.payload));
+            }
+        };
+
+        this.socket.on('state', this.socketStateListener);
+        this.socket.on('event:live', this.socketDataListener);
+        this.socketStateListener(this.socket.getState());
+    }
+
+    private removeSocketListener() {
+        if (!this.socketStateListener) {
+            return;
+        }
+
+        if (this.socket.getState() === State.Connected) {
+            this.socket.execute('liveunsubscribe', { events: [this.slug] });
+        }
+
+        this.socket.removeListener('state', this.socketStateListener);
+        this.socket.removeListener('event:live', this.socketDataListener);
+        this.socketStateListener = null;
+        this.socketDataListener = null;
+    }
+}

--- a/test/subscription.test.js
+++ b/test/subscription.test.js
@@ -1,0 +1,84 @@
+const EventEmitter = require('events').EventEmitter;
+const Carina = require('..');
+const Subscription = Carina.Subscription;
+const State = Carina.SocketState;
+
+describe('subscription class', () => {
+    let socket;
+    let subscription;
+
+    beforeEach(() => {
+        socket = new EventEmitter();
+        socket.execute = sinon.stub();
+        setState(State.Idle);
+        subscription = new Subscription(socket, 'user:1:update');
+    });
+
+    const setState = state => {
+        socket.emit('state', state);
+        socket.getState = () => state;
+    };
+
+    it('attaches listeners initially', () => {
+        subscription.add(sinon.stub());
+        expect(socket.execute).to.not.have.been.called;
+
+        setState(State.Connected);
+        expect(socket.execute).to.have.been
+        .calledWith('livesubscribe', { events: ['user:1:update'] });
+    });
+
+    it('attaches listeners if the socket is already connected', () => {
+        setState(State.Connected);
+        subscription.add(sinon.stub());
+        expect(socket.execute).to.have.been
+        .calledWith('livesubscribe', { events: ['user:1:update'] });
+    });
+
+    it('dispatches events correctly', () => {
+        const trigger = sinon.stub();
+        setState(State.Connected);
+        subscription.add(trigger);
+
+        socket.emit('event:live', { channel: 'user:2:update', payload: 'bar' });
+        expect(trigger).not.to.have.been.called;
+
+        socket.emit('event:live', { channel: 'user:1:update', payload: 'foo' });
+        expect(trigger).to.have.been.calledWith('foo');
+    });
+
+    describe('unsubscription', () => {
+        let trigger;
+
+        beforeEach(() => {
+            setState(State.Connected);
+            trigger = sinon.stub();
+            subscription.add(trigger);
+        });
+
+        it('unsubscribes successfully', () => {
+            subscription.remove(trigger);
+            expect(socket.execute).to.have.been
+            .calledWith('liveunsubscribe', { events: ['user:1:update'] });
+        });
+
+        it('does not unsubscribe with other listeners still there', () => {
+            subscription.add(sinon.stub);
+            subscription.remove(trigger);
+            expect(socket.execute).not.to.have.been.calledWith('liveunsubscribe');
+        });
+
+        it('clears all', () => {
+            subscription.removeAll();
+            expect(socket.execute).to.have.been.calledWith('liveunsubscribe');
+        });
+
+        it('does not resubscribe on reconnect without any listeners', () => {
+            subscription.remove(trigger);
+            expect(socket.execute).to.have.been.calledWith('liveunsubscribe');
+            socket.execute = sinon.stub(); // clear calls for convenience
+            setState(State.Connected);
+            expect(socket.execute).to.not.have.been.called;
+        });
+    });
+});


### PR DESCRIPTION
The Carina socket was based around the socket in beam-client-node. The node client was built around the idea that individual RPC calls (chat messages) are important to send, but this doesn't really matter for Carina, and in fact the queuing to make sure that every call went out actually has lead to some weird bugs/edge cases. Rather, Carina's use case is oriented around tying state to one socket session.

In this PR, I've simplified things a bit. I've exorcised the queue from the socket -- packets can only be sent while the socket is open, otherwise they'll fail. We have Subscription objects that track the state and add themselves to new sockets. This also adds a little feature that lets you add and remove multiple listeners, where previously remove() would remove _all_ listeners for an event.

No breaking changes.